### PR TITLE
Fix capture thumbnail preview and restore DDS→PNG conversion

### DIFF
--- a/rtx_remix_importer/core_utils.py
+++ b/rtx_remix_importer/core_utils.py
@@ -1053,6 +1053,123 @@ class TextureProcessor:
             # Restore original file format
             bl_image.file_format = orig_file_format
 
+    # --- DDS -> PNG Conversion Methods ---
+    # These were dropped during the PNG->DDS refactor above but are still
+    # relied on by capture thumbnail generation (get_thumbnail_preview) and
+    # the "Fix Broken Textures" / "Convert DDS to PNG" operators.
+
+    def convert_dds_to_png_sync(
+        self,
+        dds_path: str,
+        output_path: str,
+        progress_callback: Optional[Callable[[str], None]] = None
+    ) -> bool:
+        """Convert a single DDS file to PNG format synchronously."""
+        if not self.is_available():
+            if progress_callback:
+                progress_callback("texconv.exe not found")
+            return False
+
+        try:
+            if progress_callback:
+                progress_callback(f"Converting {os.path.basename(dds_path)} to PNG...")
+
+            output_dir = os.path.dirname(output_path)
+            os.makedirs(output_dir, exist_ok=True)
+
+            cmd = [
+                self.texconv_path,
+                dds_path,
+                "-o", output_dir,
+                "-ft", "png",
+                "-y",  # Overwrite existing
+                "-nologo",
+            ]
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                shell=False,
+                timeout=30
+            )
+
+            if result.returncode != 0:
+                if progress_callback:
+                    progress_callback(f"texconv failed: {result.stderr}")
+                return False
+
+            # texconv names the output after the input file's base name
+            original_name = os.path.splitext(os.path.basename(dds_path))[0]
+            texconv_output = os.path.join(output_dir, f"{original_name}.png")
+
+            if os.path.exists(texconv_output):
+                if texconv_output != output_path:
+                    os.replace(texconv_output, output_path)
+                if progress_callback:
+                    progress_callback("Conversion complete")
+                return True
+            else:
+                if progress_callback:
+                    progress_callback("texconv output file not found")
+                return False
+
+        except subprocess.TimeoutExpired:
+            if progress_callback:
+                progress_callback("texconv timed out")
+            return False
+        except Exception as e:
+            if progress_callback:
+                progress_callback(f"Error: {e}")
+            return False
+
+    async def convert_dds_to_png_async(
+        self,
+        dds_path: str,
+        output_path: str,
+        progress_callback: Optional[Callable[[str], None]] = None
+    ) -> bool:
+        """Convert DDS file to PNG format asynchronously."""
+        if not self.is_available():
+            if progress_callback:
+                progress_callback("texconv.exe not found")
+            return False
+
+        def _convert():
+            return self.convert_dds_to_png_sync(dds_path, output_path, progress_callback)
+
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(get_thread_pool(), _convert)
+
+    def batch_convert_dds_to_png(
+        self,
+        dds_files: List[str],
+        output_dir: str,
+        progress_callback: Optional[Callable[[int, int, str], None]] = None
+    ) -> List[str]:
+        """Batch convert multiple DDS files to PNG. Returns list of output PNG paths."""
+        if not self.is_available():
+            return []
+
+        converted_files = []
+        total_files = len(dds_files)
+
+        for i, dds_file in enumerate(dds_files):
+            if progress_callback:
+                progress_callback(i, total_files, f"Converting {os.path.basename(dds_file)}")
+
+            base_name = os.path.splitext(os.path.basename(dds_file))[0]
+            output_path = os.path.join(output_dir, f"{base_name}.png")
+
+            if self.convert_dds_to_png_sync(dds_file, output_path):
+                converted_files.append(output_path)
+
+        if progress_callback:
+            progress_callback(total_files, total_files, "Batch conversion complete")
+
+        return converted_files
+
     # Legacy method names for backward compatibility
     async def convert_texture_async(self, bl_image, output_path, dds_format='BC7_UNORM_SRGB', progress_callback=None):
         """Legacy method - use convert_png_to_dds_async instead."""

--- a/rtx_remix_importer/ui/properties.py
+++ b/rtx_remix_importer/ui/properties.py
@@ -1,12 +1,26 @@
 import bpy
 from .operators.capture_ops import auto_scan_capture_folder
 from .capture_list import RemixCaptureListItem
+from .capture_panel import load_thumbnail
 
 # --- Scene Properties ---
 
 def poll_is_mesh_object(self, object):
     """ Poll function for PointerProperty to allow selecting only MESH objects. """
     return object.type == 'MESH'
+
+def on_capture_index_update(self, context):
+    """Load the thumbnail for the newly selected capture immediately.
+
+    Relying solely on depsgraph_update_post is not enough: simply changing
+    the active index of the capture UIList (a plain Scene IntProperty) does
+    not trigger a depsgraph update, so the preview would never load/refresh
+    when clicking through the list.
+    """
+    captures = self.remix_captures
+    index = self.remix_captures_index
+    if 0 <= index < len(captures):
+        load_thumbnail(captures[index].full_path)
 
 def register_properties():
     bpy.types.Scene.remix_mod_file_path = bpy.props.StringProperty(
@@ -122,7 +136,11 @@ def register_properties():
 
     # --- UIList Properties ---
     bpy.types.Scene.remix_captures = bpy.props.CollectionProperty(type=RemixCaptureListItem)
-    bpy.types.Scene.remix_captures_index = bpy.props.IntProperty(name="Capture List Index", default=0)
+    bpy.types.Scene.remix_captures_index = bpy.props.IntProperty(
+        name="Capture List Index",
+        default=0,
+        update=on_capture_index_update,
+    )
 
     bpy.types.Scene.remix_project_root = bpy.props.StringProperty(
         name="Project Root",


### PR DESCRIPTION
## Summary

Two independent bugs affecting texture/capture previews:

1. **Capture thumbnail never loads on selection.** `remix_captures_index` had no `update` callback, so clicking a capture in the list didn't trigger thumbnail loading — it relied entirely on `depsgraph_update_post`, which doesn't fire on a simple Scene property change. Fixed by loading the thumbnail directly via an `update` callback on the index property.

2. **DDS→PNG conversion methods missing after the PNG→DDS refactor.** `TextureProcessor` gained `convert_png_to_dds_sync/async` but lost `convert_dds_to_png_sync`, `convert_dds_to_png_async`, and `batch_convert_dds_to_png` in the process, while three call sites still depended on them:
   - `get_thumbnail_preview()` (capture previews)
   - `FixBrokenTextures` / "Convert DDS to PNG" operators
   - the async DDS cleanup path in `texture_cleanup_operator.py`

   This caused `AttributeError: 'TextureProcessor' object has no
   attribute 'batch_convert_dds_to_png'` when running "Fix Broken
   Textures", among other failures.

## Changes

- `ui/properties.py`: add `on_capture_index_update` callback on `remix_captures_index`.
- `core_utils.py`: restore `convert_dds_to_png_sync`, `convert_dds_to_png_async`, and `batch_convert_dds_to_png` on `TextureProcessor`, unchanged in behavior/signature from the pre-refactor implementation.

## Testing

- Verified capture thumbnail now loads immediately when clicking through the capture list.
- Verified "Fix Broken Textures" completes without AttributeError.
- Ran a static check across the codebase for any other calls to now-nonexistent `TextureProcessor` methods — none found.
- All modified files compile cleanly (`python -m py_compile`).

## Notes

No changes needed to `ui/project_panel.py` — the sublayer-unpacking crash reported earlier against the previous release has already been fixed upstream in this branch (dict-based format with legacy tuple fallback).